### PR TITLE
fix(storybook-preview): use fullscreen layout option

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -8,6 +8,7 @@ import '../src/scss/utility/index.scss?global';
 
 export default {
   parameters: {
+    layout: 'fullscreen',
     actions: { argTypesRegex: '^on.*' },
     controls: {
       matchers: {


### PR DESCRIPTION
Update Storybook preview to use the fullscreen layout option so full bleed components work as expected.
